### PR TITLE
docs: fix simple typo, propert -> property

### DIFF
--- a/src/underscore.py
+++ b/src/underscore.py
@@ -124,7 +124,7 @@ class underscore(object):
 
     @obj.setter
     def obj(self, value):
-        """ New style classes requires setters for @propert methods
+        """ New style classes requires setters for @property methods
         """
         self.object = value
         return self.object


### PR DESCRIPTION
There is a small typo in src/underscore.py.

Should read `property` rather than `propert`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md